### PR TITLE
[Week 1] Gemini Rate Limiting Implementation

### DIFF
--- a/src/agent_auditor/adapters/gemini.py
+++ b/src/agent_auditor/adapters/gemini.py
@@ -6,6 +6,7 @@ Implements:
 - Rate limit handling with exponential backoff
 - Secure API key handling (via SecureKeyManager)
 - Token usage tracking
+- Proactive RPM/TPM rate limiting
 """
 
 import asyncio
@@ -14,6 +15,7 @@ from typing import Optional, Tuple
 
 from agent_auditor.errors import APIKeyNotFoundError, RateLimitError
 from agent_auditor.models import AITask
+from agent_auditor.rate_limiter import RateLimiter, get_rate_limiter
 from agent_auditor.security import SecureKeyManager
 from agent_auditor.settings import GeminiSettings, get_settings
 
@@ -37,7 +39,8 @@ class GeminiAdapter:
         api_key: Optional[str] = None,
         max_retries: Optional[int] = None,
         base_retry_delay: Optional[float] = None,
-        settings: Optional[GeminiSettings] = None
+        settings: Optional[GeminiSettings] = None,
+        rate_limiter: Optional[RateLimiter] = None
     ) -> None:
         """
         Initialize the Gemini adapter.
@@ -47,6 +50,7 @@ class GeminiAdapter:
             max_retries: Maximum retry attempts on 429 errors.
             base_retry_delay: Base delay for exponential backoff (seconds).
             settings: Optional GeminiSettings, otherwise uses global settings.
+            rate_limiter: Optional RateLimiter for RPM/TPM enforcement.
             
         Raises:
             APIKeyNotFoundError: If no API key is available.
@@ -57,6 +61,9 @@ class GeminiAdapter:
         self.max_retries = max_retries if max_retries is not None else self._settings.max_retries
         self.base_retry_delay = base_retry_delay if base_retry_delay is not None else self._settings.base_retry_delay
         self.default_model = self._settings.default_model
+        
+        # Rate limiter for RPM/TPM enforcement
+        self._rate_limiter = rate_limiter or get_rate_limiter()
         
         # Handle explicit key or read from environment
         if api_key:
@@ -83,12 +90,13 @@ class GeminiAdapter:
         # Client will be configured on first use
         self._client = None
     
-    async def call(self, task: AITask) -> Tuple[str, int]:
+    async def call(self, task: AITask, estimated_tokens: int = 500) -> Tuple[str, int]:
         """
-        Execute an AI task.
+        Execute an AI task with rate limiting.
         
         Args:
             task: The AITask to execute.
+            estimated_tokens: Estimated tokens for rate limiting (default 500).
             
         Returns:
             Tuple of (response_text, tokens_used).
@@ -96,12 +104,18 @@ class GeminiAdapter:
         Raises:
             RateLimitError: If max retries exceeded.
         """
+        # Acquire rate limit before proceeding
+        await self._rate_limiter.acquire(estimated_tokens)
+        
         retries = 0
         last_error = None
         
         while retries <= self.max_retries:
             try:
-                return await self._generate(task)
+                response, tokens_used = await self._generate(task)
+                # Record actual usage for rate limiter
+                self._rate_limiter.record_usage(tokens_used, estimated_tokens)
+                return response, tokens_used
             except RateLimitError as e:
                 last_error = e
                 retries += 1

--- a/src/agent_auditor/rate_limiter.py
+++ b/src/agent_auditor/rate_limiter.py
@@ -1,0 +1,194 @@
+"""
+Rate Limiter for Gemini API.
+
+Implements token bucket algorithm for RPM/TPM limits.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class RateLimitConfig:
+    """Configuration for rate limiting."""
+    rpm_limit: int = 60  # Requests per minute (free tier default)
+    tpm_limit: int = 60_000  # Tokens per minute (Gemini Pro free tier)
+    refill_interval: float = 60.0  # Seconds for bucket refill
+
+
+@dataclass
+class TokenBucket:
+    """Token bucket for rate limiting."""
+    capacity: int
+    tokens: float = field(init=False)
+    last_refill: float = field(init=False)
+    refill_rate: float = field(init=False)
+    
+    def __post_init__(self):
+        self.tokens = float(self.capacity)
+        self.last_refill = time.monotonic()
+        # Tokens refill per second to reach capacity in 60s
+        self.refill_rate = self.capacity / 60.0
+    
+    def _refill(self) -> None:
+        """Refill tokens based on elapsed time."""
+        now = time.monotonic()
+        elapsed = now - self.last_refill
+        self.tokens = min(self.capacity, self.tokens + elapsed * self.refill_rate)
+        self.last_refill = now
+    
+    def consume(self, amount: int = 1) -> bool:
+        """
+        Attempt to consume tokens.
+        
+        Returns:
+            True if tokens consumed, False if insufficient.
+        """
+        self._refill()
+        if self.tokens >= amount:
+            self.tokens -= amount
+            return True
+        return False
+    
+    def wait_time(self, amount: int = 1) -> float:
+        """
+        Calculate wait time to have enough tokens.
+        
+        Returns:
+            Seconds to wait, or 0 if tokens available.
+        """
+        self._refill()
+        if self.tokens >= amount:
+            return 0.0
+        needed = amount - self.tokens
+        return needed / self.refill_rate
+    
+    @property
+    def available(self) -> float:
+        """Return available tokens."""
+        self._refill()
+        return self.tokens
+
+
+class RateLimiter:
+    """
+    Rate limiter for Gemini API with RPM and TPM enforcement.
+    
+    Ensures no 429 errors are passed to human users by:
+    1. Tracking request rate (RPM)
+    2. Tracking token rate (TPM)
+    3. Proactively waiting when limits approach
+    
+    Example:
+        limiter = RateLimiter()
+        await limiter.acquire(estimated_tokens=500)
+        # Make API call...
+        limiter.record_usage(actual_tokens=478)
+    """
+    
+    def __init__(self, config: Optional[RateLimitConfig] = None) -> None:
+        """Initialize rate limiter with config."""
+        self.config = config or RateLimitConfig()
+        
+        # Token buckets for RPM and TPM
+        self._rpm_bucket = TokenBucket(capacity=self.config.rpm_limit)
+        self._tpm_bucket = TokenBucket(capacity=self.config.tpm_limit)
+        
+        # Lock for thread-safe operations
+        self._lock = asyncio.Lock()
+    
+    async def acquire(self, estimated_tokens: int = 100) -> None:
+        """
+        Acquire permission to make an API call.
+        
+        Waits if necessary to avoid hitting rate limits.
+        
+        Args:
+            estimated_tokens: Estimated tokens for the request.
+        """
+        async with self._lock:
+            # Check both limits
+            rpm_wait = self._rpm_bucket.wait_time(1)
+            tpm_wait = self._tpm_bucket.wait_time(estimated_tokens)
+            
+            wait_time = max(rpm_wait, tpm_wait)
+            
+            if wait_time > 0:
+                await asyncio.sleep(wait_time)
+            
+            # Consume from both buckets
+            self._rpm_bucket.consume(1)
+            self._tpm_bucket.consume(estimated_tokens)
+    
+    def record_usage(self, actual_tokens: int, estimated_tokens: int = 100) -> None:
+        """
+        Record actual token usage after API call.
+        
+        Adjusts TPM bucket if actual differs from estimated.
+        
+        Args:
+            actual_tokens: Actual tokens used.
+            estimated_tokens: Previously estimated tokens.
+        """
+        # Adjust TPM bucket for difference
+        diff = actual_tokens - estimated_tokens
+        if diff > 0:
+            # Used more than estimated, consume difference
+            self._tpm_bucket.tokens = max(0, self._tpm_bucket.tokens - diff)
+        elif diff < 0:
+            # Used less than estimated, give back difference
+            self._tpm_bucket.tokens = min(
+                self._tpm_bucket.capacity,
+                self._tpm_bucket.tokens - diff
+            )
+    
+    def can_proceed(self, estimated_tokens: int = 100) -> bool:
+        """
+        Check if a call can proceed without waiting.
+        
+        Returns:
+            True if both RPM and TPM limits allow.
+        """
+        return (
+            self._rpm_bucket.wait_time(1) == 0 and
+            self._tpm_bucket.wait_time(estimated_tokens) == 0
+        )
+    
+    @property
+    def rpm_available(self) -> float:
+        """Return available RPM quota."""
+        return self._rpm_bucket.available
+    
+    @property
+    def tpm_available(self) -> float:
+        """Return available TPM quota."""
+        return self._tpm_bucket.available
+    
+    def get_status(self) -> dict:
+        """Return current limiter status."""
+        return {
+            "rpm_available": round(self.rpm_available, 1),
+            "rpm_limit": self.config.rpm_limit,
+            "tpm_available": round(self.tpm_available),
+            "tpm_limit": self.config.tpm_limit,
+        }
+
+
+# Global singleton for shared limiting
+_global_limiter: Optional[RateLimiter] = None
+
+
+def get_rate_limiter(config: Optional[RateLimitConfig] = None) -> RateLimiter:
+    """Get or create the global rate limiter."""
+    global _global_limiter
+    if _global_limiter is None:
+        _global_limiter = RateLimiter(config)
+    return _global_limiter
+
+
+def reset_rate_limiter() -> None:
+    """Reset global rate limiter (for testing)."""
+    global _global_limiter
+    _global_limiter = None


### PR DESCRIPTION
## Summary
Implements proactive RPM/TPM rate limiting for Gemini API adapter.

## Changes
- **rate_limiter.py**: New TokenBucket-based rate limiter
  - RPM limit: 60 requests/minute (free tier default)
  - TPM limit: 60,000 tokens/minute (Gemini Pro free tier)
  - Proactive waiting before API calls
  - Usage tracking after calls

- **gemini.py**: Integrated rate limiter
  - Calls `acquire()` before API requests
  - Calls `record_usage()` after responses
  - Added `estimated_tokens` parameter

## Acceptance Criteria
- [x] RPM/TPM limit enforcement
- [x] Exponential backoff on 429 (already existed)
- [x] Zero 429 errors passed to humans (proactive limiting)

Closes #3